### PR TITLE
fix a few null pointer crashes and container serialization issues

### DIFF
--- a/Source/VendingMachines/Comp/CompVendingMachine.cs
+++ b/Source/VendingMachines/Comp/CompVendingMachine.cs
@@ -39,7 +39,7 @@ namespace VendingMachines
             Scribe_Values.Look(ref pricing, "pricing", 2);
             Scribe_Values.Look(ref lastEmptyTick, "lastEmptyTick");
             Scribe_Values.Look(ref totalSold, "totalSold");
-            Scribe_Deep.Look(ref silverContainer, "silverContainer");
+            Scribe_Deep.Look(ref silverContainer, "silverContainer", this);
         }
 
         public bool IsActive() => isActive || Properties.noToggle;
@@ -160,7 +160,10 @@ namespace VendingMachines
 
         public override void PostDestroy(DestroyMode mode, Map previousMap)
         {
-            MainContainer.TryDropAll(parent.OccupiedRect().Cells.RandomElement(), previousMap, ThingPlaceMode.Near);
+            if (previousMap != null)
+            {
+                MainContainer.TryDropAll(parent.OccupiedRect().Cells.RandomElement(), previousMap, ThingPlaceMode.Near);
+            }
             MainContainer.ClearAndDestroyContents();
             base.PostDestroy(mode, previousMap);
         }

--- a/Source/VendingMachines/EmptyVendingMachine/JobDriver_EmptyVendingMachine.cs
+++ b/Source/VendingMachines/EmptyVendingMachine/JobDriver_EmptyVendingMachine.cs
@@ -14,7 +14,8 @@ namespace VendingMachines
 
         public override bool TryMakePreToilReservations(bool errorOnFailed)
         {
-            return pawn.Reserve(VendingMachine.parent, job, 1, 1, null, errorOnFailed);
+            var target = job.GetTarget(IndexVM).Thing;
+            return target != null && pawn.Reserve(target, job, 1, 1, null, errorOnFailed);
         }
 
         public override IEnumerable<Toil> MakeNewToils()

--- a/Source/VendingMachines/JoyGiver/JoyGiver_BuyStuff.cs
+++ b/Source/VendingMachines/JoyGiver/JoyGiver_BuyStuff.cs
@@ -35,7 +35,7 @@ namespace VendingMachines
             var map = pawn.MapHeld;
             var requiresFoodFactor = GuestUtility.GetRequiresFoodFactor(pawn);
             var storage = vendingMachines.OfType<Building_Storage>();
-            List<Thing> things = storage.SelectMany(s => s.slotGroup.HeldThings.Where(t => ItemUtility.IsBuyableNow(pawn, t) && Qualifies(t, pawn))).ToList();
+            List<Thing> things = storage.Where(s => s.slotGroup != null).SelectMany(s => s.slotGroup.HeldThings.Where(t => ItemUtility.IsBuyableNow(pawn, t) && Qualifies(t, pawn))).ToList();
             
             if (things.Count == 0)
             {
@@ -81,7 +81,9 @@ namespace VendingMachines
             }
 
             //Log.Message($"{pawn.NameShortColored} is going to buy {thing.LabelShort} at {thing.Position}.");
-            return new Job(jobDefBuy, thing, vendingMachines.First(cell => cell is Building_Storage b && b.slotGroup.HeldThings.Contains(thing)));
+            var storageBuilding = vendingMachines.FirstOrDefault(cell => cell is Building_Storage b && b.slotGroup?.HeldThings?.Contains(thing) == true);
+            if (storageBuilding == null) return null;
+            return new Job(jobDefBuy, thing, storageBuilding);
         }
 
         private static float Likey(Pawn pawn, Thing thing, float requiresFoodFactor)


### PR DESCRIPTION
- fixed silver container losing owner reference after loading a save
- added null check for previous map in PostDestroy to stop crashes on unspawned building destruction
- added null checks for storage slotgroup and building lookups in JoyGiver_BuyStuff to prevent guest AI errors
- fixed potential null dereference in JobDriver_EmptyVendingMachine reservation check